### PR TITLE
STRK-832 | Adicionando os dias 24 e 31 como feriados.

### DIFF
--- a/lib/Date/Holidays/BR.pm
+++ b/lib/Date/Holidays/BR.pm
@@ -148,7 +148,9 @@ sub holidays {
          15 => 'Proclamação da República',
        },
       12 => {
+         24 => 'Véspera de Natal',
          25 => 'Natal',
+         31 => 'Véspera de Ano Novo',
        },
   );
 


### PR DESCRIPTION
# Tickets no Merge Request

[STRK-832 - Adicionar dias 24/12 e 31/12 como feriados](https://estantevirtual.atlassian.net/browse/STRK-832)

## Resumo:

Adicionando os dias 24 e 31 como feriados, já que o Correios não funciona nesses dias.