### PR TITLE
STRK-855 | Adicionando o dia 25/1 na lista de feriados.

### DIFF
--- a/lib/Date/Holidays/BR.pm
+++ b/lib/Date/Holidays/BR.pm
@@ -130,6 +130,7 @@ sub holidays {
   my %holidays = (
        1 => {
           1 => 'Confraternização Universal',
+          25 => 'Aniversário de São Paulo',
        },
        4 => {
          21 => 'Tiradentes',


### PR DESCRIPTION
[STRK-855 - Transformar dia 25/01 em feriado nacional](https://estantevirtual.atlassian.net/browse/STRK-855) 

## Resumo:

Adicionando o dia 25/1 na lista de feriados.

## Lista de Checagem:

- [x] Todos os testes estão passando?
- [x] A cobertura de testes continua acima dos **80%**?
- [x] Fez um teste manual de fluxo para validar que foi feito o que foi solitado?