### PR TITLE
Inserindo novos feriados que foram adiantados

### DIFF
--- a/lib/Date/Holidays/BR.pm
+++ b/lib/Date/Holidays/BR.pm
@@ -185,10 +185,14 @@ sub year_holidays {
           26 => 'Quarta-feira de Cinzas',
         },
         4 => {
-          10 => 'Paixão de Cristo'
+          10 => 'Paixão de Cristo',
+        },
+        5 => {
+          20 => 'Dia da consciência negra',
+          21 => 'Nossa Senhora Aparecida',
         },
         10 => {
-          19 => 'Dia do Comércio'
+          19 => 'Dia do Comércio',
         },
       },
       2021 => {


### PR DESCRIPTION
Foi solicitado que fossem adiantados os feriados de dia da consciência negra e de nossa senhora da aparecida nas datas 20 e 21 de maio de 2020.